### PR TITLE
Speed up local parallel smoke with shared per-worker sessions

### DIFF
--- a/PROJECT_PROGRESS.md
+++ b/PROJECT_PROGRESS.md
@@ -801,3 +801,19 @@ Update this file after:
 - The 3 skips are the known intentional ones: invoice payment (INVOICE_REFERENCE not set) and both cart flows (no stable supplier yet)
 - `test_smoke_catalog_has_suppliers` passed in this run as well
 - Guard fix along the way: the local-parallel protection no longer blocks browser-only runs (`-m web -n 2`); mixed expressions still trip it
+
+## Update On 2026-06-10 (One Login Per Worker Session, Home As Test Start Point)
+
+- Smoke fixture architecture was reworked at the user request:
+  - one session-scoped ManagedDriverSession per pytest worker serves all OnlineDuken tests
+  - the phone/SMS/PIN login runs once when the worker session is first built (serialized across workers by the login lock)
+  - the contract for every OnlineDuken test is: start from OnlineDuken home, re-established between tests; the restart ladder rebuilds the session with a fresh login only when it dies
+  - the two native-shell tests intentionally keep fresh per-test sessions: they are the dedicated login/entry checks
+  - run_local_smoke.ps1 defaults to EntryMode=full; mobile smoke no longer depends on auth tokens (tokens remain the web-tier mechanism)
+- Measured effect on the 2-worker two-emulator bench:
+  - before: 8 passed, 3 skipped in 21:58 (about 19 minutes inside fixtures, including one anomalous 740s payments session build)
+  - after: 8 passed, 3 skipped in 5:21; navigation tests cost 3-5s each against the shared session
+- One flake was caught and fixed along the way:
+  - qr-common failed once with a fully valid payment screen that never reacted to the single pay-button tap; it passed standalone immediately after
+  - submit_qr_payment now re-taps the pay button once after 10 quiet seconds and the submission timeout grew 15s -> 30s
+- Verification chain for this rework: ruff clean, 54 unit tests, full -n 2 smoke green twice (8:07 with one QR flake, then 5:21 fully green after the re-tap fix)

--- a/PROJECT_PROGRESS.md
+++ b/PROJECT_PROGRESS.md
@@ -788,3 +788,16 @@ Update this file after:
 - This also live-validated refactor-branch internals end to end: flows package, runtime_auth, login lock, OnlineDuken entry
 - Practical daily loop: `run_local_smoke.ps1 -BootstrapOnly` once, then develop against `run_web_suite.ps1` in seconds-long iterations
 - CI note: the app-login bootstrap cannot run on GitHub runners (no emulator); push web smoke still needs the internal login endpoint secrets or a token secret
+
+## Update On 2026-06-10 (Local Two-Emulator Parallel Smoke Green)
+
+- Full local verification pass after the refactor merge, all tiers:
+  - unit: `54 passed`
+  - web suite sequential: `5 passed in 43.01s`
+  - web suite `-n 2`: `5 passed in 27.73s`
+  - full mobile smoke `-n 2` on two emulators: `8 passed, 3 skipped, 0 failed in 21:58`
+- The two-emulator parallel bench (emulator-5554 + Medium_Phone_Parallel on 5556, Appium 4723/4725, LOCAL_ANDROID_DEVICE_MATRIX mapping) was historically "up but unstable for long runs"; this is its first fully green long run
+  - likely contributors: refactor stability work, app-state reuse, APPIUM_NO_RESET changes, and the login lock serializing shared-phone logins
+- The 3 skips are the known intentional ones: invoice payment (INVOICE_REFERENCE not set) and both cart flows (no stable supplier yet)
+- `test_smoke_catalog_has_suppliers` passed in this run as well
+- Guard fix along the way: the local-parallel protection no longer blocks browser-only runs (`-m web -n 2`); mixed expressions still trip it

--- a/mobile_automation/qr_flow.py
+++ b/mobile_automation/qr_flow.py
@@ -290,10 +290,11 @@ def wait_for_qr_payment_screen(driver, timeout: int = 45) -> None:
     _wait_for_native_presence(driver, NativePaymentPage.PAY_BUTTON, timeout=timeout)
 
 
-def submit_qr_payment(driver, timeout: int = 15) -> str:
+def submit_qr_payment(driver, timeout: int = 30) -> str:
     _wait_for_native_presence(driver, NativePaymentPage.PAY_BUTTON, timeout=20).click()
     starting_activity = getattr(driver, "current_activity", "")
     end = time.time() + timeout
+    retap_at = time.time() + 10
 
     while time.time() < end:
         page_source = driver.page_source
@@ -317,6 +318,18 @@ def submit_qr_payment(driver, timeout: int = 15) -> str:
 
         if not driver.find_elements(*NativePaymentPage.PAY_BUTTON):
             return "pay_button_disappeared"
+
+        if time.time() >= retap_at:
+            # A single tap on the native pay button occasionally does not
+            # register. Repeating it here is safe: the screen provably has
+            # not reacted yet (same activity, button present, no toast).
+            retap_at = float("inf")
+            try:
+                buttons = driver.find_elements(*NativePaymentPage.PAY_BUTTON)
+                if buttons:
+                    buttons[0].click()
+            except WebDriverException:
+                logger.debug("pay button re-tap failed; keeping the wait loop", exc_info=True)
 
         time.sleep(1)
 

--- a/scripts/run_local_smoke.ps1
+++ b/scripts/run_local_smoke.ps1
@@ -3,7 +3,9 @@ param(
     [switch]$SafeSmoke,
     [switch]$BootstrapOnly,
     [switch]$Allure,
-    [string]$EntryMode = "token",
+    # Full phone login is affordable now that it runs once per worker session;
+    # tests start from OnlineDuken home instead of re-entering through auth.
+    [string]$EntryMode = "full",
     [string]$BaseAvdName = "Medium_Phone_API_36.0",
     [string]$ParallelAvdName = "Medium_Phone_Parallel",
     [string]$AllureResultsDir = "allure-results"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -198,6 +198,14 @@ def pytest_configure_node(node) -> None:
     node.workerinput[LOCAL_WORKER_APPIUM_URL] = local_devices[worker_index].appium_server_url
 
 
+def _markexpr_limits_run_to_web(config: pytest.Config) -> bool:
+    # `web and <anything>` can only select web-marked tests, so requiring
+    # `web` as a top-level conjunct is a sound (conservative) check.
+    markexpr = getattr(config.option, "markexpr", "") or ""
+    conjuncts = {part.strip().strip("()") for part in markexpr.split(" and ")}
+    return "web" in conjuncts
+
+
 def pytest_sessionstart(session: pytest.Session) -> None:
     if hasattr(session.config, "workerinput"):
         return
@@ -212,6 +220,11 @@ def pytest_sessionstart(session: pytest.Session) -> None:
 
     settings = get_settings()
     if settings.is_browserstack:
+        return
+
+    if _markexpr_limits_run_to_web(session.config):
+        # Browser-only runs never touch Android devices, so the local
+        # device matrix does not constrain them.
         return
 
     local_devices = settings.resolved_local_android_devices

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -416,9 +416,8 @@ def _prepare_managed_onlineduken_home(manager: ManagedDriverSession, settings: S
 
 
 @pytest.fixture(scope="function")
-def auth_smoke_driver(driver, settings: Settings):
-    enter_onlineduken(driver, settings)
-    return driver
+def auth_smoke_driver(onlineduken_session_manager: ManagedDriverSession, settings: Settings):
+    return _prepare_managed_onlineduken_home(onlineduken_session_manager, settings, "auth_smoke_prepare")
 
 
 @pytest.fixture(scope="function")
@@ -457,41 +456,40 @@ def web_driver(settings: Settings, web_auth_url: str):
             driver.quit()
 
 
-def _module_session_manager(settings: Settings, session_label: str):
-    manager = ManagedDriverSession(settings, session_name=f"OnlineDuken {session_label}")
+@pytest.fixture(scope="session")
+def onlineduken_session_manager(settings: Settings, appium_service):
+    # One mobile session per pytest worker: the phone/SMS/PIN login runs once
+    # when the first test builds the driver, and every OnlineDuken test then
+    # starts from OnlineDuken home re-established between tests. The managed
+    # restart ladder rebuilds the session (with a fresh login) only if it dies.
+    manager = ManagedDriverSession(settings, session_name="OnlineDuken shared smoke")
     try:
         yield manager
     finally:
         manager.close()
 
 
-@pytest.fixture(scope="module")
-def ui_session_manager(settings: Settings, appium_service):
-    yield from _module_session_manager(settings, "UI smoke")
-
-
-@pytest.fixture(scope="module")
-def payments_session_manager(settings: Settings, appium_service):
-    yield from _module_session_manager(settings, "payments smoke")
-
-
 @pytest.fixture(scope="function")
-def ui_smoke_driver(ui_session_manager: ManagedDriverSession, settings: Settings):
-    driver = _prepare_managed_onlineduken_home(ui_session_manager, settings, "ui_smoke_prepare")
+def ui_smoke_driver(onlineduken_session_manager: ManagedDriverSession, settings: Settings):
+    driver = _prepare_managed_onlineduken_home(onlineduken_session_manager, settings, "ui_smoke_prepare")
     yield driver
     with suppress(Exception):
-        if ui_session_manager.active_driver is not None:
-            recover_onlineduken_home(ui_session_manager.active_driver, settings, capture_prefix="ui_smoke_cleanup")
-
-
-@pytest.fixture(scope="function")
-def payments_smoke_driver(payments_session_manager: ManagedDriverSession, settings: Settings):
-    driver = _prepare_managed_onlineduken_home(payments_session_manager, settings, "payments_smoke_prepare")
-    yield driver
-    with suppress(Exception):
-        if payments_session_manager.active_driver is not None:
+        if onlineduken_session_manager.active_driver is not None:
             recover_onlineduken_home(
-                payments_session_manager.active_driver,
+                onlineduken_session_manager.active_driver,
+                settings,
+                capture_prefix="ui_smoke_cleanup",
+            )
+
+
+@pytest.fixture(scope="function")
+def payments_smoke_driver(onlineduken_session_manager: ManagedDriverSession, settings: Settings):
+    driver = _prepare_managed_onlineduken_home(onlineduken_session_manager, settings, "payments_smoke_prepare")
+    yield driver
+    with suppress(Exception):
+        if onlineduken_session_manager.active_driver is not None:
+            recover_onlineduken_home(
+                onlineduken_session_manager.active_driver,
                 settings,
                 capture_prefix="payments_smoke_cleanup",
             )


### PR DESCRIPTION
## What changed

- **One logged-in session per pytest worker.** Module-scoped session managers multiplied Appium sessions after the smoke suite was split into topic files; now a single session-scoped ManagedDriverSession serves all OnlineDuken tests on a worker. The phone/SMS/PIN login runs once when the session is first built, serialized across workers by the login lock.
- **Every test starts from OnlineDuken home**, re-established between tests. The restart ladder rebuilds the session (with a fresh login) only when it dies. The two native-shell tests intentionally keep fresh per-test sessions - they are the dedicated login/entry checks.
- run_local_smoke.ps1 defaults to EntryMode=full: the phone login is affordable at once-per-worker, and mobile smoke no longer depends on auth tokens (tokens remain the web-tier mechanism).
- **QR pay-button re-tap**: submit_qr_payment repeats the tap once after 10 quiet seconds (safe: same activity, button still present, no toast) and the submission timeout grew 15s -> 30s. Fixes a flake where a fully valid payment screen never reacted to the single tap.
- **Local-parallel guard exempts browser-only runs**: pytest -m web -n 2 no longer requires a local Android device matrix; mixed marker expressions still trip the guard.
- Progress notes for both milestones in PROJECT_PROGRESS.md.

## Why

Fixture overhead dominated the local parallel smoke: a 2-worker run spent about 19 of 22 minutes inside session setup/teardown, including one anomalous 740s payments-session build.

## Verification

- ruff clean, 54 unit tests green, 76 tests collect
- Full smoke -n 2 on two emulators: 21:58 before -> 8:07 after the session rework (one QR flake) -> **5:21 fully green** after the re-tap fix (8 passed, 3 skipped)
- Web suite -n 2: 5 passed in 27.7s
- The 3 skips are the known intentional ones: invoice payment (no INVOICE_REFERENCE) and both cart flows (stable supplier pending)

🤖 Generated with [Claude Code](https://claude.com/claude-code)